### PR TITLE
Feat: implement main functions and structures used for the reduction + build_phi_5-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ doc
 
 # Executable
 graphProblemSolver
+
+sol/default.formula
+sol/default_Sat.dot

--- a/include/EdgeConProblem/EdgeConGraph.h
+++ b/include/EdgeConProblem/EdgeConGraph.h
@@ -4,9 +4,9 @@
  * @brief  Structure to store a graph with heterogeneous edges informations for the EdgeCon Problem
  * @version 1
  * @date 2021-10-18
- * 
+ *
  * @copyright Creative Commons.
- * 
+ *
  */
 
 #ifndef COCA_EDGECONGRAPH_H
@@ -23,7 +23,7 @@ typedef struct EdgeConGraph_s *EdgeConGraph;
 
 /**
  * @brief Initializes the struct from a graph. Does NOT creates a copy of the graph. Starts with empty translators.
- * 
+ *
  * @param graph A graph
  * @return EdgeConGraph The corresponding EdgeConGraph with no translator.
  * @pre @p graph must be a valid graph.
@@ -32,7 +32,7 @@ EdgeConGraph initializeGraph(Graph graph);
 
 /**
  * @brief Get the Graph to manipulate it.
- * 
+ *
  * @param graph An EdgeConGraph
  * @return Graph The graph without translators and components informations.
  */
@@ -40,7 +40,7 @@ Graph getGraph(const EdgeConGraph graph);
 
 /**
  * @brief Resets the translator set to empty, and recomputes heterogeneous edges and connected components.
- * 
+ *
  * @param graph A EdgeConGraph.
  * @pre @p graph must be valid.
  */
@@ -48,20 +48,20 @@ void resetTranslator(EdgeConGraph graph);
 
 /**
  * @brief Frees the additional informations of a EdgeConGraph, but NOT the graph (cf initialize).
- * 
+ *
  * @param graph A EdgeConGraph.
- * 
+ *
  * @pre @p graph must be valid.
  */
 void deleteEdgeConGraph(EdgeConGraph graph);
 
 /**
  * @brief Set the edge (@p node1,@p node2) as heterogeneous (if it exists, otherwise does nothing).
- * 
+ *
  * @param graph A EdgeConGraph.
  * @param node1 A node.
  * @param node2 A node.
- * 
+ *
  * @pre @p graph must be valid.
  * @pre @p node1 < @p graph->graph.numNodes.
  * @pre @p node2 < @p graph->graph.numNodes.
@@ -70,11 +70,11 @@ void setHeterogeneousEdge(EdgeConGraph graph, int node1, int node2);
 
 /**
  * @brief Set the edge (@p node1,@p node2) as heterogeneous (if it exists, otherwise does nothing).
- * 
+ *
  * @param graph A EdgeConGraph.
  * @param node1 A node.
  * @param node2 A node.
- * 
+ *
  * @pre @p graph must be valid.
  * @pre @p node1 < @p graph->graph.numNodes.
  * @pre @p node2 < @p graph->graph.numNodes.
@@ -83,12 +83,12 @@ void SetHomogeneousEdge(EdgeConGraph graph, int node1, int node2);
 
 /**
  * @brief
- * 
+ *
  * @param graph A EdgeConGraph.
  * @param node1 A node.
  * @param node2 A node.
  * @return True if (@p node1, @p node2) is an homogeneous edge.
- * 
+ *
  * @pre @p graph must be valid.
  * @pre @p node1 < @p graph.graph.numNodes.
  * @pre @p node2 < @p graph.graph.numNodes.
@@ -97,12 +97,12 @@ bool isEdgeHomogeneous(const EdgeConGraph graph, int node1, int node2);
 
 /**
  * @brief
- * 
+ *
  * @param graph A EdgeConGraph.
  * @param node1 A node.
  * @param node2 A node.
  * @return True if (@p node1, @p node2) is an heterogeneous edge.
- * 
+ *
  * @pre @p graph must be valid.
  * @pre @p node1 < @p graph.graph.numNodes.
  * @pre @p node2 < @p graph.graph.numNodes.
@@ -111,31 +111,35 @@ bool isEdgeHeterogeneous(const EdgeConGraph graph, int node1, int node2);
 
 /**
  * @brief Get the number of heterogeneous edges.
- * 
+ *
  * @param graph An EdgeConGraph
  * @return int the number of heterogeneous edges.
  */
 int getNumHeteregeneousEdges(const EdgeConGraph graph);
 
 /**
- * @brief Sets the edge (@p node1,@p node2) to be a translator. Warning: DOES NOT recompute homogeneous components, you must use computesHomogeneousComponents if you wont them to be updated.
- * 
+ * @brief Sets the edge (@p node1,@p node2) to be a translator. Warning:
+ * DOES NOT recompute homogeneous components, you must use
+ * computesHomogeneousComponents if you wont them to be updated.
+ *
  * @param graph A EdgeConGraph.
  * @param node1 A node.
  * @param node2 A node.
- * 
+ *
  * @pre graph must be valid.
  * @pre node < graph.graph.numNodes.
  */
 void addTranslator(EdgeConGraph graph, int node1, int node2);
 
 /**
- * @brief Sets the edge (@p node1,@p node2) to not be a translator. Warning: DOES NOT recompute homogeneous components, you must use computesHomogeneousComponents if you wont them to be updated.
- * 
+ * @brief Sets the edge (@p node1,@p node2) to not be a translator. Warning:
+ * DOES NOT recompute homogeneous components, you must use
+ * computesHomogeneousComponents if you wont them to be updated.
+ *
  * @param graph A EdgeConGraph.
  * @param node1 A node.
  * @param node2 A node.
- * 
+ *
  * @pre graph must be valid.
  * @pre node < graph.graph.numNodes.
  */
@@ -143,7 +147,7 @@ void removeTranslator(EdgeConGraph graph, int node1, int node2);
 
 /**
  * @brief Tells if (@p node1,@p node2) bears a translator.
- * 
+ *
  * @param graph An EdgeConGraph
  * @param node1 A node
  * @param node2 A node
@@ -154,22 +158,22 @@ bool isTranslator(const EdgeConGraph graph, int node1, int node2);
 
 /**
  * @brief Computes the homogeneous components.
- * 
+ *
  * @param graph a EdgeConGraph.
- * 
+ *
  * @pre graph must be a valid EdgeConGraph.
  */
 void computesHomogeneousComponents(EdgeConGraph graph);
 
 /**
  * @brief Tests if @p node1 and @p node2 are in the same homogeneous component.
- * 
+ *
  * @param graph A EdgeConGraph.
  * @param node1 A node.
  * @param node2 A node.
  * @return true If @p node1 and @p node2 are in the same homogeneous component.
  * @return false Otherwise.
- * 
+ *
  * @pre @p graph must be a valid EdgeConGraph
  * @pre @p node1 < @p graph.graph.numNodes
  * @pre @p node2 < @p graph.graph.numNodes
@@ -178,7 +182,7 @@ bool areInSameComponent(const EdgeConGraph graph, int node1, int node2);
 
 /**
  * @brief Tells if @p node is in the homogeneous component @p component
- * 
+ *
  * @param graph An EdgeConGraph
  * @param node A node
  * @param component The number of a component
@@ -189,7 +193,7 @@ bool isNodeInComponent(const EdgeConGraph graph, int node, int component);
 
 /**
  * @brief Get the number of homogeneous components in @p graph.
- * 
+ *
  * @param graph An EdgeConGraph
  * @return int The number of homogeneous components
  */
@@ -197,7 +201,7 @@ int getNumComponents(const EdgeConGraph graph);
 
 /**
  * @brief Displays the translator set of the EdgeConGraph.
- * 
+ *
  * @param graph A EdgeConGraph.
  * @pre @p graph must be a valid EdgeConGraph.
  */
@@ -205,7 +209,7 @@ void printTranslator(const EdgeConGraph graph);
 
 /**
  * @brief Creates the file ("%s.dot",name) representing the solution to the problem described by @p set, or ("result.dot") if name is NULL.
- * 
+ *
  * @param graph A graph.
  * @param name The name of the output file.
  * @pre @p graph must be a valid graph.

--- a/include/main/Z3Tools.h
+++ b/include/main/Z3Tools.h
@@ -6,9 +6,9 @@
  *        every time needed.
  * @version 1
  * @date 2019-08-01
- * 
+ *
  * @copyright Creative Commons
- * 
+ *
  */
 
 #ifndef COCA_Z3TOOLS_H_
@@ -19,7 +19,7 @@
 
 /**
  * @brief Creates a basic Z3 context with basic config (sufficient for this project). Must be freed at end of program with Z3_del_context.
- * 
+ *
  * @return Z3_context The created context
  */
 Z3_context makeContext(void);
@@ -27,7 +27,7 @@ Z3_context makeContext(void);
 /**
  * @brief Creates a formula containing a single variable whose name is given in parameter. Example mk_bool_var(ctx,"toto") will create the formula «toto». Each call with
  *        same name will produce the same formula (so it can be used to have the same variable in different formulae.)
- * 
+ *
  * @param ctx The context of the solver.
  * @param name The name the variable.
  * @return Z3_ast The formula consisting in the variable.
@@ -36,7 +36,7 @@ Z3_ast mk_bool_var(Z3_context ctx, const char * name);
 
 /**
  * @brief Tells if a formula is satisfiable, unsatisfiable, or cannot be decided.
- * 
+ *
  * @param ctx The context of the solver.
  * @param formula The formula to check.
  * @return Z3_lbool Z3_L_FALSE if @p formula is unsatisfiable, Z3_L_TRUE if @p formula is satisfiable and Z3_L_UNDEF if the solver cannot decide if @p formula is
@@ -46,7 +46,7 @@ Z3_lbool isFormulaSat(Z3_context ctx, Z3_ast formula);
 
 /**
  * @brief Returns an assignment of variables satisfying the formula if it is satisfiable. Exits the program if the formula is unsatisfiable.
- * 
+ *
  * @param ctx The context of the solver.
  * @param formula The formula to get a model from.
  * @return Z3_model An assignment of variable satisfying @p formula.
@@ -55,7 +55,7 @@ Z3_model getModelFromSatFormula(Z3_context ctx, Z3_ast formula);
 
 /**
  * @brief Checks if a formula is satisfiable, unsatisfiable, or cannot be decided. If it is decidable, puts a model in the formula in model.
- * 
+ *
  * @param ctx The context of the solver.
  * @param formula The formula to check.
  * @param model A pointer towards a model. Will contain a model of @p formula if it is satisfiable (otherwise, will not be modified).
@@ -64,8 +64,10 @@ Z3_model getModelFromSatFormula(Z3_context ctx, Z3_ast formula);
 Z3_lbool solveFormula(Z3_context ctx, Z3_ast formula, Z3_model* model);
 
 /**
- * @brief Returns the truth value of the formula @p variable in the variable assignment @p model. Very usefull if @p variable is a formula containing a single variable.
- * 
+ * @brief Returns the truth value of the formula @p variable in the variable
+ * assignment @p model. Very usefull if @p variable is a formula containing a
+ * single variable.
+ *
  * @param ctx The context of the solver.
  * @param model A variable assignment.
  * @param variable A formula of which we want the truth value.

--- a/src/EdgeConProblem/EdgeConReduction.c
+++ b/src/EdgeConProblem/EdgeConReduction.c
@@ -8,6 +8,8 @@
 #include "EdgeConReduction.h"
 #include "Z3Tools.h"
 
+#define MAX(X, Y) X > Y ? X : Y
+
 /** Macros used to improve the readability of formula construction. */
 
 #define NOT(X) Z3_mk_not(ctx->z3_ctx, X)
@@ -37,8 +39,6 @@ static Z3_ast build_phi_3(const g_context_s *ctx);
 static Z3_ast build_phi_4(const g_context_s *ctx);
 
 /**
- * FIXME: needs to manage the case k > N.
- *
  * Builds the formula ensuring the constraint:
  *
  *   "The tree has a depth strictly greater than k."
@@ -150,13 +150,13 @@ Z3_ast EdgeConReduction(Z3_context z3_ctx, EdgeConGraph edgeGraph, int cost) {
     ctx = init_g_context(z3_ctx, edgeGraph, cost);
 
     return(
-        OR(5)
+        AND(5)
             build_phi_2(ctx),
             build_phi_3(ctx),
             build_phi_4(ctx),
             build_phi_5(ctx),
             build_phi_8(ctx)
-        EOR
+        EAND
     );
 }
 
@@ -184,7 +184,10 @@ static Z3_ast build_phi_4(const g_context_s *ctx) { return Z3_mk_false(ctx->z3_c
 
 static Z3_ast build_phi_5(const g_context_s *ctx) {
     int pos;
-    Z3_ast literals[ctx->C_H * (ctx->N - ctx->k)];
+    Z3_ast literals[
+        ctx->C_H *
+        (ctx->N <= ctx->k ? ctx->N : (ctx->N - ctx->k))
+    ];
 
     pos = 0;
     for (int i = 0; i < ctx->C_H; ++i) {

--- a/src/EdgeConProblem/EdgeConReduction.c
+++ b/src/EdgeConProblem/EdgeConReduction.c
@@ -201,8 +201,8 @@ static Z3_ast build_phi_6(const g_context_s *ctx, const int j1, const int j2) {
     Z3_ast literals[ctx->m * ctx->N];
 
     pos = 0;
-    for (int u = 0; u < ctx->m; ++u) {
-        for (int v = u + 1; v < ctx->m; ++v) {
+    for (int u = 0; u < ctx->n; ++u) {
+        for (int v = u + 1; v < ctx->n; ++v) {
             if (isEdge(ctx->G, u, v) &&
                 isNodeInComponent(ctx->graph, u, j1) &&
                 isNodeInComponent(ctx->graph, v, j2)) {
@@ -261,15 +261,15 @@ static Z3_ast build_phi_8(const g_context_s *ctx) {
 }
 
 void getTranslatorSetFromModel(Z3_context ctx, Z3_model model, EdgeConGraph graph) {
-    int m;
+    int n;
     int N;
 
-    m = getGraph(graph).numEdges;
+    n = getGraph(graph).numNodes;
     computesHomogeneousComponents(graph);
     N = getNumComponents(graph) - 1;
 
-    for (int n1 = 0; n1 < m; ++n1) {
-        for (int n2 = n1; n2 < m; ++n2) {
+    for (int n1 = 0; n1 < n; ++n1) {
+        for (int n2 = n1; n2 < n; ++n2) {
             for (int i = 0; i < N; ++i) {
                 if (is_the_ith_translator(ctx, model, graph, n1, n2, i)) {
                     addTranslator(graph, n1, n2);

--- a/src/EdgeConProblem/EdgeConReduction.c
+++ b/src/EdgeConProblem/EdgeConReduction.c
@@ -8,36 +8,74 @@
 #include "EdgeConReduction.h"
 #include "Z3Tools.h"
 
-Z3_ast getVariableIsIthTranslator(Z3_context ctx, int node1, int node2, int number)
-{
+/** Stores all needed data used to build formulas. */
+typedef struct {
+    unsigned int n;     ///< The numbers of vertex.
+    unsigned int m;     ///< The number of edges.
+    unsigned int N;     ///< The minimal number of translator.
+    int C_H;            ///< The number of homogeneous components.
+    int k;              ///< The maximum cost of a simple and valid path between two vertex.
+    Graph G;            ///< The graph.
+    EdgeConGraph graph; ///< The EdgeConGraph.
+    Z3_context z3_ctx;  ///< The current Z3 context.
+} g_context_s;
+
+Z3_ast getVariableIsIthTranslator(Z3_context ctx, int node1, int node2, int number) {
     char name[40];
-    if (node1 < node2)
+
+    if (node1 < node2) {
         snprintf(name, 40, "[(%d,%d),%d]", node1, node2, number);
-    else
+    }
+    else {
         snprintf(name, 40, "[(%d,%d),%d]", node2, node1, number);
+    }
+
     return mk_bool_var(ctx, name);
 }
 
-Z3_ast getVariableParent(Z3_context ctx, int child, int parent)
-{
+Z3_ast getVariableParent(Z3_context ctx, int child, int parent) {
     char name[40];
+
     snprintf(name, 40, "p_[%d,%d]", child, parent);
+
     return mk_bool_var(ctx, name);
 }
 
-Z3_ast getVariableLevelInSpanningTree(Z3_context ctx, int level, int component)
-{
+Z3_ast getVariableLevelInSpanningTree(Z3_context ctx, int level, int component) {
     char name[40];
+
     snprintf(name, 40, "l_[%d,%d]", component, level);
+
     return mk_bool_var(ctx, name);
 }
 
-Z3_ast EdgeConReduction(Z3_context ctx, EdgeConGraph edgeGraph, int cost)
-{
     return Z3_mk_false(ctx);
+Z3_ast EdgeConReduction(Z3_context ctx, EdgeConGraph edgeGraph, int cost) {
+    g_context_s *gctx;
+
+    gctx = init_g_context(ctx, edgeGraph, cost);
+
 }
 
-void getTranslatorSetFromModel(Z3_context ctx, Z3_model model, EdgeConGraph graph)
-{
+static g_context_s* init_g_context(Z3_context z3_ctx, EdgeConGraph graph, int cost) {
+    g_context_s *ctx = NULL;
+
+    ctx = malloc(sizeof(g_context_s));
+    assert( NULL != ctx );
+
+    ctx->graph = graph;
+    ctx->G = getGraph(graph);
+    ctx->n = ctx->G.numNodes;
+    ctx->m = ctx->G.numEdges;
+    ctx->C_H = getNumComponents(graph);
+    ctx->N = ctx->C_H - 1;
+    ctx->k = cost;
+    ctx->z3_ctx = z3_ctx;
+
+    return ctx;
+}
+
+
+void getTranslatorSetFromModel(Z3_context ctx, Z3_model model, EdgeConGraph graph) {
     return;
 }

--- a/src/EdgeConProblem/EdgeConReduction.c
+++ b/src/EdgeConProblem/EdgeConReduction.c
@@ -20,6 +20,13 @@ typedef struct {
     Z3_context z3_ctx;  ///< The current Z3 context.
 } g_context_s;
 
+static Z3_ast build_phi_2(g_context_s *ctx);
+static Z3_ast build_phi_3(g_context_s *ctx);
+static Z3_ast build_phi_4(g_context_s *ctx);
+static Z3_ast build_phi_5(g_context_s *ctx);
+static Z3_ast build_phi_8(g_context_s *ctx);
+static g_context_s* init_g_context(Z3_context z3_ctx, EdgeConGraph graph, int cost);
+
 Z3_ast getVariableIsIthTranslator(Z3_context ctx, int node1, int node2, int number) {
     char name[40];
 
@@ -49,12 +56,19 @@ Z3_ast getVariableLevelInSpanningTree(Z3_context ctx, int level, int component) 
     return mk_bool_var(ctx, name);
 }
 
-    return Z3_mk_false(ctx);
 Z3_ast EdgeConReduction(Z3_context ctx, EdgeConGraph edgeGraph, int cost) {
     g_context_s *gctx;
 
     gctx = init_g_context(ctx, edgeGraph, cost);
 
+    return Z3_mk_and(ctx, 5, (Z3_ast [5]) {
+            build_phi_2(gctx),
+            build_phi_3(gctx),
+            build_phi_4(gctx),
+            build_phi_5(gctx),
+            build_phi_8(gctx)
+        }
+    );
 }
 
 static g_context_s* init_g_context(Z3_context z3_ctx, EdgeConGraph graph, int cost) {
@@ -75,6 +89,25 @@ static g_context_s* init_g_context(Z3_context z3_ctx, EdgeConGraph graph, int co
     return ctx;
 }
 
+static Z3_ast build_phi_2(g_context_s *ctx) { return Z3_mk_false(ctx->z3_ctx); }
+static Z3_ast build_phi_3(g_context_s *ctx) { return Z3_mk_false(ctx->z3_ctx); }
+static Z3_ast build_phi_4(g_context_s *ctx) { return Z3_mk_false(ctx->z3_ctx); }
+
+static Z3_ast build_phi_5(g_context_s *ctx) {
+    int pos;
+    Z3_ast literals[ctx->C_H * (ctx->N - ctx->k)];
+
+    pos = 0;
+    for (int i = 0; i < ctx->C_H; ++i) {
+        for (int n = ctx->k; n < ctx->N; ++n) {
+            literals[pos++] = getVariableLevelInSpanningTree(ctx->z3_ctx, n, i);
+        }
+    }
+
+    return Z3_mk_or(ctx->z3_ctx, pos, literals);
+}
+
+static Z3_ast build_phi_8(g_context_s *ctx) { return Z3_mk_false(ctx->z3_ctx); }
 
 void getTranslatorSetFromModel(Z3_context ctx, Z3_model model, EdgeConGraph graph) {
     return;


### PR DESCRIPTION
## Changelog

* New structure `g_context_s` used to store global data and reduce the number of arguments for auxiliary functions.
* New macros to build formulas.
* Implement `build_phi_5-8`.
* Implement `getSetTranslatorFromModel`.
* Implement `EdgeConReduction`.
* Setup the structure of `EdgeConReduction`.

## Issue

@HugoPasquier @PlanteVerte  I don't know how we should manage the case `k` > `N` for the `phi_5`.